### PR TITLE
Fixed angle calculations and out of bounds errors

### DIFF
--- a/src/vector_pursuit_controller.cpp
+++ b/src/vector_pursuit_controller.cpp
@@ -281,10 +281,11 @@ double VectorPursuitController::calcTurningRadius(
       double phi_1 = std::atan2(
         (2 * std::pow(target_pose.pose.position.y, 2) - std::pow(distance, 2)),
         (2 * target_pose.pose.position.x * target_pose.pose.position.y));
-      double phi_2 = std::atan2(std::pow(distance, 2), (2 * target_pose.pose.position.y));
-      double phi = angles::normalize_angle(phi_1 - phi_2);
-      double term_1 = (k_ * phi) / (((k_ - 1) * phi) + target_angle);
       double term_2 = std::pow(distance, 2) / (2 * target_pose.pose.position.y);
+      double phi_2 = std::atan2(term_2, 0.0);
+      double phi = angles::normalize_angle_positive(phi_1 - phi_2);
+      phi = std::max(phi, 1.0e-9);
+      double term_1 = (k_ * phi) / (((k_ - 1) * phi) + target_angle);
       turning_radius = std::abs(term_1 * term_2);
     } else {
       // Handle case when target is directly ahead

--- a/test/test_vector_pursuit.cpp
+++ b/test/test_vector_pursuit.cpp
@@ -424,13 +424,13 @@ TEST(VectorPursuitTest, calcTurnRadius) {
 
   EXPECT_NEAR(ctrl->calcTurningRadiusWrappper(carrot), 0.11, 0.01);
 
-  // beside
+  // left
   carrot.pose.position.x = 0.0;
   carrot.pose.position.y = 0.1;
 
   EXPECT_NEAR(ctrl->calcTurningRadiusWrappper(carrot), 0.05, 0.01);
 
-  // beside, rotated 90 degrees
+  // left, rotated 180 degrees
   carrot.pose.position.x = 0.0;
   carrot.pose.position.y = 0.1;
 
@@ -438,7 +438,7 @@ TEST(VectorPursuitTest, calcTurnRadius) {
   tf2_quat.setRPY(0, 0, -M_PI);
   carrot.pose.orientation = tf2::toMsg(tf2_quat);
 
-  EXPECT_NEAR(ctrl->calcTurningRadiusWrappper(carrot), 0.04, 0.01);
+  EXPECT_NEAR(ctrl->calcTurningRadiusWrappper(carrot), 0.0, 0.01);
 }
 
 TEST(VectorPursuitTest, rotateTests)


### PR DESCRIPTION
# Fixed Calculation Error in `phi_2`  and other edge cases
Fixes #11

## Problem  
The controller experienced NaN errors and incorrect angle normalization in `calcTurningRadius()` due to:  
- Incorrect `phi_2` calculation. 
- Improper clamping of the `phi` angle (should be within (0, 2π].  
- Incorrect use of `normalize_angle()` instead of `normalize_angle_positive()`. 

## Changes  
- Replaced `normalize_angle()` with `angles::normalize_angle_positive()`.  
- Properly clamped `phi` to the range (0, 2π] to prevent invalid values.  
- Implemented a minimum value clamp for `phi` to prevent division by zero.  
- Fixed `phi_2` computation to always be ±π/2 based on the sign condition.  

## Testing  
- Path tracking remains smooth through curves.  
- No more NaN errors in edge cases.  
- Correct angle normalization verified.  
- Stable turning radius calculations under all conditions.  

## Notes  
Makes the controller more numerically stable and fixes the implementation to be aligned with the paper