### PR TITLE
Add explicit angles dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(pluginlib REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(angles REQUIRED)
 
 nav2_package()
 set(CMAKE_CXX_STANDARD 17)
@@ -34,6 +35,7 @@ set(dependencies
   tf2
   tf2_geometry_msgs
   tf2_ros
+  angles
 )
 
 set(library_name vector_pursuit_controller)

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>angles</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
This PR adds `angles` as an explicit dependency of `vector_pursuit_controller`.

`src/vector_pursuit_controller.cpp` directly includes `angles/angles.h` and uses APIs including `angles::normalize_angle` and `angles::normalize_angle_positive` in the controller implementation.

Currently, `angles` appears to be available transitively through Navigation2 dependencies such as `nav2_controller` or `nav2_costmap_2d`. This change makes the package manifest and CMake configuration match the direct source usage.

Changes:

- Add `<depend>angles</depend>` to `package.xml`.
- Add `find_package(angles REQUIRED)` to `CMakeLists.txt`.
- Add `angles` to the target/export dependency list.